### PR TITLE
Fixed login prone to timeout

### DIFF
--- a/itchat/components/login.py
+++ b/itchat/components/login.py
@@ -67,6 +67,7 @@ def login(self, enableCmdQR=False, picDir=None, qrCallback=None,
                 if isLoggedIn is not None:
                     logger.info('Please press confirm on your phone.')
                     isLoggedIn = None
+                time.sleep(0.5)
             elif status != '408':
                 break
         if isLoggedIn:


### PR DESCRIPTION
如题, ItChat-UOS 在 Linux 环境下会弹出二次确认登录页面, 且强制要求等待5秒, 及其容易触发二维码超时. 试验证明轮询登录状态时加延迟动作可规避.